### PR TITLE
fix: correct updateMetadata test compilation

### DIFF
--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
@@ -198,7 +198,7 @@ internal class NamespaceServiceAsyncTest {
     @Test
     fun updateMetadata() {
         val client = TurbopufferOkHttpClientAsync.builder().apiKey("tpuf_A1...").build()
-        val namespaceServiceAsync = client.namespaces()
+        val namespaceServiceAsync = client.namespace("ns")
 
         val namespaceMetadataFuture =
             namespaceServiceAsync.updateMetadata(

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
@@ -188,7 +188,7 @@ internal class NamespaceServiceTest {
     @Test
     fun updateMetadata() {
         val client = TurbopufferOkHttpClient.builder().apiKey("tpuf_A1...").build()
-        val namespaceService = client.namespaces()
+        val namespaceService = client.namespace("ns")
 
         val namespaceMetadata =
             namespaceService.updateMetadata(


### PR DESCRIPTION
## Summary
- The `updateMetadata` tests added in d7ccbf6 call `client.namespaces()` (returns a `ClientNamespacesPage`) instead of `client.namespace("ns")` (returns a `NamespaceService` that has the `updateMetadata` method)
- This caused `compileTestKotlin` to fail with "Unresolved reference: updateMetadata"

## Test plan
- [x] `./gradlew compileTestKotlin` passes locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that corrects a service accessor to resolve a compilation error; no production logic is modified.
> 
> **Overview**
> Fixes the `updateMetadata` tests (blocking and async) to call `client.namespace("ns")` instead of `client.namespaces()`, so the tests reference a `NamespaceService` that actually exposes `updateMetadata` and `compileTestKotlin` no longer fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a6ac8b7c6fbcad29c239d56b6af1fda38573c64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->