### PR TITLE
docs: add UPGRADING.md with v2.0 breaking changes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -60,29 +60,6 @@ changes.
   );
   ```
 
-- The top-level `Query` builder used by `multiQuery` has been moved to
-  `NamespaceMultiQueryParams.Query`.
-
-  Old:
-
-  ```java
-  ns.multiQuery(
-    NamespaceMultiQueryParams.builder()
-      .addQuery(Query.builder().rankBy(/* ... */).build())
-      .build()
-  );
-  ```
-
-  New:
-
-  ```java
-  ns.multiQuery(
-    NamespaceMultiQueryParams.builder()
-      .addQuery(NamespaceMultiQueryParams.Query.builder().rankBy(/* ... */).build())
-      .build()
-  );
-  ```
-
 - The `encryption` parameter has been restructured.
 
   Old:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,59 @@ changes.
 
 ## v2.0
 
+- The `RankBy.vector` factory has been renamed to `RankBy.ann`.
+
+  Old:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .rankBy(RankBy.vector("vector", List.of(0.1f, 0.2f)))
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .rankBy(RankBy.ann("vector", List.of(0.1f, 0.2f)))
+      .build()
+  );
+  ```
+
+- The `encryption` parameter has been restructured.
+
+  Old:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .addUpsertRow(/* ... */)
+      .encryption(
+        NamespaceWriteParams.Encryption.builder()
+          .cmek(NamespaceWriteParams.Encryption.Cmek.builder().keyName("...").build())
+          .build()
+      )
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .addUpsertRow(/* ... */)
+      .encryption(Encryption.CustomerManaged.builder().keyName("...").build())
+      .build()
+  );
+  ```
+
+  A new `default` variant lets you migrate a namespace from CMEK to default
+  encryption.
+
 - The `copyFromNamespace` parameter on `NamespaceWriteParams` has been removed
   in favor of a dedicated `copyFrom` method. The nested
   `CopyFromNamespaceConfig` builder has been replaced by a flat
@@ -56,59 +109,6 @@ changes.
   ns.branchFrom(
     NamespaceBranchFromParams.builder()
       .sourceNamespace("src")
-      .build()
-  );
-  ```
-
-- The `encryption` parameter has been restructured.
-
-  Old:
-
-  ```java
-  ns.write(
-    NamespaceWriteParams.builder()
-      .addUpsertRow(/* ... */)
-      .encryption(
-        NamespaceWriteParams.Encryption.builder()
-          .cmek(NamespaceWriteParams.Encryption.Cmek.builder().keyName("...").build())
-          .build()
-      )
-      .build()
-  );
-  ```
-
-  New:
-
-  ```java
-  ns.write(
-    NamespaceWriteParams.builder()
-      .addUpsertRow(/* ... */)
-      .encryption(Encryption.CustomerManaged.builder().keyName("...").build())
-      .build()
-  );
-  ```
-
-  A new `default` variant lets you migrate a namespace from CMEK to default
-  encryption.
-
-- The `RankBy.vector` factory has been renamed to `RankBy.ann`.
-
-  Old:
-
-  ```java
-  ns.query(
-    NamespaceQueryParams.builder()
-      .rankBy(RankBy.vector("vector", List.of(0.1f, 0.2f)))
-      .build()
-  );
-  ```
-
-  New:
-
-  ```java
-  ns.query(
-    NamespaceQueryParams.builder()
-      .rankBy(RankBy.ann("vector", List.of(0.1f, 0.2f)))
       .build()
   );
   ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,8 +83,7 @@ changes.
   );
   ```
 
-- The `encryption` parameter has been restructured. A new `default` variant
-  lets you explicitly opt out of CMEK on writes to a CMEK-enabled namespace.
+- The `encryption` parameter has been restructured.
 
   Old:
 
@@ -111,6 +110,9 @@ changes.
       .build()
   );
   ```
+
+  A new `default` variant lets you explicitly opt out of CMEK on writes to a
+  CMEK-enabled namespace.
 
 ## v1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -113,12 +113,6 @@ changes.
   );
   ```
 
-- The `Query` builder used by `multiQuery` has been moved out of
-  `NamespaceMultiQueryParams` into a top-level class at
-  `com.turbopuffer.models.namespaces.Query`. The nested
-  `NamespaceMultiQueryParams.Query` is retained as a typealias for
-  compatibility.
-
 - `NamespaceQueryParams.builder().groupBy()` now takes `List<GroupBy>` instead
   of `List<String>`. Wrap plain attribute names with `GroupBy.attr`.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -28,6 +28,29 @@ changes.
   );
   ```
 
+- `NamespaceQueryParams.builder().groupBy()` now takes `List<GroupBy>` instead
+  of `List<String>`. Wrap plain attribute names with `GroupBy.attr`.
+
+  Old:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .groupBy(List.of("color", "size"))
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .groupBy(List.of(GroupBy.attr("color"), GroupBy.attr("size")))
+      .build()
+  );
+  ```
+
 - The `encryption` parameter has been restructured.
 
   Old:
@@ -109,29 +132,6 @@ changes.
   ns.branchFrom(
     NamespaceBranchFromParams.builder()
       .sourceNamespace("src")
-      .build()
-  );
-  ```
-
-- `NamespaceQueryParams.builder().groupBy()` now takes `List<GroupBy>` instead
-  of `List<String>`. Wrap plain attribute names with `GroupBy.attr`.
-
-  Old:
-
-  ```java
-  ns.query(
-    NamespaceQueryParams.builder()
-      .groupBy(List.of("color", "size"))
-      .build()
-  );
-  ```
-
-  New:
-
-  ```java
-  ns.query(
-    NamespaceQueryParams.builder()
-      .groupBy(List.of(GroupBy.attr("color"), GroupBy.attr("size")))
       .build()
   );
   ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,6 +83,42 @@ changes.
   );
   ```
 
+- The `encryption` parameter on `NamespaceWriteParams` now takes a top-level
+  `Encryption` discriminated union (with `Encryption.CustomerManaged` and a
+  `default` variant) rather than `NamespaceWriteParams.Encryption` with a
+  nested `Cmek` builder. The new `default` variant lets you explicitly opt
+  out of CMEK on writes to a CMEK-enabled namespace.
+
+  Old:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .addUpsertRow(/* ... */)
+      .encryption(
+        NamespaceWriteParams.Encryption.builder()
+          .cmek(NamespaceWriteParams.Encryption.Cmek.builder().keyName("...").build())
+          .build()
+      )
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .addUpsertRow(/* ... */)
+      .encryption(
+        Encryption.ofCustomerManaged(
+          Encryption.CustomerManaged.builder().keyName("...").build()
+        )
+      )
+      .build()
+  );
+  ```
+
 ## v1.0
 
 No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,88 @@
+# Upgrade guide
+
+This document describes the notable breaking changes, if any, in each version of
+the Java client. See [CHANGELOG.md](./CHANGELOG.md) for a comprehensive list of
+changes.
+
+## v2.0
+
+- The `copyFromNamespace` parameter on `NamespaceWriteParams` has been removed
+  in favor of a dedicated `copyFrom` method. The nested
+  `CopyFromNamespaceConfig` builder has been replaced by a flat
+  `NamespaceCopyFromParams` builder.
+
+  Old:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .copyFromNamespace(
+        CopyFromNamespaceParams.CopyFromNamespaceConfig.builder()
+          .sourceNamespace("src")
+          .sourceRegion("gcp-us-central1")
+          .build()
+      )
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.copyFrom(
+    NamespaceCopyFromParams.builder()
+      .sourceNamespace("src")
+      .sourceRegion("gcp-us-central1")
+      .build()
+  );
+  ```
+
+- The `branchFromNamespace` parameter on `NamespaceWriteParams` has been removed
+  in favor of a dedicated `branchFrom` method.
+
+  Old:
+
+  ```java
+  ns.write(
+    NamespaceWriteParams.builder()
+      .branchFromNamespace("src")
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.branchFrom(
+    NamespaceBranchFromParams.builder()
+      .sourceNamespace("src")
+      .build()
+  );
+  ```
+
+- The top-level `Query` builder used by `multiQuery` has been moved to
+  `NamespaceMultiQueryParams.Query`.
+
+  Old:
+
+  ```java
+  ns.multiQuery(
+    NamespaceMultiQueryParams.builder()
+      .addQuery(Query.builder().rankBy(/* ... */).build())
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.multiQuery(
+    NamespaceMultiQueryParams.builder()
+      .addQuery(NamespaceMultiQueryParams.Query.builder().rankBy(/* ... */).build())
+      .build()
+  );
+  ```
+
+## v1.0
+
+No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -91,8 +91,27 @@ changes.
   A new `default` variant lets you migrate a namespace from CMEK to default
   encryption.
 
-- The `RankBy.vector` and `RankBy.sparseVector` factories have been renamed
-  to `RankBy.ann` and `RankBy.sparseKnn`.
+- The `RankBy.vector` factory has been renamed to `RankBy.ann`.
+
+  Old:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .rankBy(RankBy.vector("vector", List.of(0.1f, 0.2f)))
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .rankBy(RankBy.ann("vector", List.of(0.1f, 0.2f)))
+      .build()
+  );
+  ```
 
 - The `Query` builder used by `multiQuery` has been moved out of
   `NamespaceMultiQueryParams` into a top-level class at

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,9 +83,7 @@ changes.
   encryption.
 
 - The `copyFromNamespace` parameter on `NamespaceWriteParams` has been removed
-  in favor of a dedicated `copyFrom` method. The nested
-  `CopyFromNamespaceConfig` builder has been replaced by a flat
-  `NamespaceCopyFromParams` builder.
+  in favor of a dedicated `copyFrom` method.
 
   Old:
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -90,3 +90,35 @@ changes.
 
   A new `default` variant lets you migrate a namespace from CMEK to default
   encryption.
+
+- The `RankBy.vector` and `RankBy.sparseVector` factories have been renamed
+  to `RankBy.ann` and `RankBy.sparseKnn`.
+
+- The `Query` builder used by `multiQuery` has been moved out of
+  `NamespaceMultiQueryParams` into a top-level class at
+  `com.turbopuffer.models.namespaces.Query`. The nested
+  `NamespaceMultiQueryParams.Query` is retained as a typealias for
+  compatibility.
+
+- `NamespaceQueryParams.builder().groupBy()` now takes `List<GroupBy>` instead
+  of `List<String>`. Wrap plain attribute names with `GroupBy.attr`.
+
+  Old:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .groupBy(List.of("color", "size"))
+      .build()
+  );
+  ```
+
+  New:
+
+  ```java
+  ns.query(
+    NamespaceQueryParams.builder()
+      .groupBy(List.of(GroupBy.attr("color"), GroupBy.attr("size")))
+      .build()
+  );
+  ```

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -111,5 +111,5 @@ changes.
   );
   ```
 
-  A new `default` variant lets you explicitly opt out of CMEK on writes to a
-  CMEK-enabled namespace.
+  A new `default` variant lets you migrate a namespace from CMEK to default
+  encryption.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -113,7 +113,3 @@ changes.
 
   A new `default` variant lets you explicitly opt out of CMEK on writes to a
   CMEK-enabled namespace.
-
-## v1.0
-
-No significant changes.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -83,11 +83,8 @@ changes.
   );
   ```
 
-- The `encryption` parameter on `NamespaceWriteParams` now takes a top-level
-  `Encryption` discriminated union (with `Encryption.CustomerManaged` and a
-  `default` variant) rather than `NamespaceWriteParams.Encryption` with a
-  nested `Cmek` builder. The new `default` variant lets you explicitly opt
-  out of CMEK on writes to a CMEK-enabled namespace.
+- The `encryption` parameter has been restructured. A new `default` variant
+  lets you explicitly opt out of CMEK on writes to a CMEK-enabled namespace.
 
   Old:
 
@@ -110,11 +107,7 @@ changes.
   ns.write(
     NamespaceWriteParams.builder()
       .addUpsertRow(/* ... */)
-      .encryption(
-        Encryption.ofCustomerManaged(
-          Encryption.CustomerManaged.builder().keyName("...").build()
-        )
-      )
+      .encryption(Encryption.CustomerManaged.builder().keyName("...").build())
       .build()
   );
   ```


### PR DESCRIPTION
Adds an UPGRADING.md modeled after the Python and TypeScript clients. Documents the v2.0 breaking changes inferred from the docs samples:

- `copyFromNamespace` write parameter replaced by a dedicated `copyFrom` method, with the nested `CopyFromNamespaceConfig` builder flattened into `NamespaceCopyFromParams`.
- `branchFromNamespace` write parameter replaced by a dedicated `branchFrom` method.
- `Query` builder for multi-query moved to `NamespaceMultiQueryParams.Query`.

Also adds a stub v1.0 entry noting no significant changes.