### PR TITLE
feat: transparent async polling

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/ClientOptions.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/ClientOptions.kt
@@ -9,6 +9,7 @@ import com.turbopuffer.core.http.HttpClient
 import com.turbopuffer.core.http.LoggingHttpClient
 import com.turbopuffer.core.http.PhantomReachableClosingHttpClient
 import com.turbopuffer.core.http.QueryParams
+import com.turbopuffer.core.http.RespondAsyncHttpClient
 import com.turbopuffer.core.http.RetryingHttpClient
 import java.time.Clock
 import java.time.Duration
@@ -564,27 +565,33 @@ private constructor(
                 }
             }
 
+            val clientHeaders = headers.build()
             return ClientOptions(
                 httpClient,
-                RetryingHttpClient.builder()
-                    .httpClient(
-                        LoggingHttpClient.builder()
-                            .httpClient(httpClient)
-                            .clock(clock)
-                            .level(logLevel)
-                            .build()
-                    )
-                    .sleeper(sleeper)
-                    .clock(clock)
-                    .maxRetries(maxRetries)
-                    .build(),
+                RespondAsyncHttpClient(
+                    RetryingHttpClient.builder()
+                        .httpClient(
+                            LoggingHttpClient.builder()
+                                .httpClient(httpClient)
+                                .clock(clock)
+                                .level(logLevel)
+                                .build()
+                        )
+                        .sleeper(sleeper)
+                        .clock(clock)
+                        .maxRetries(maxRetries)
+                        .build(),
+                    sleeper,
+                    jsonMapper,
+                    clientHeaders,
+                ),
                 checkJacksonVersionCompatibility,
                 jsonMapper,
                 streamHandlerExecutor,
                 sleeper,
                 clock,
                 baseUrl,
-                headers.build(),
+                clientHeaders,
                 queryParams.build(),
                 responseValidation,
                 timeout,

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
@@ -1,0 +1,191 @@
+package com.turbopuffer.core.http
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.turbopuffer.core.RequestOptions
+import com.turbopuffer.core.Sleeper
+import com.turbopuffer.core.Timeout
+import com.turbopuffer.errors.TurbopufferException
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.net.URI
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+
+private const val PREFER_HEADER = "Prefer"
+private const val PREFERENCE_APPLIED_HEADER = "Preference-Applied"
+private const val LOCATION_HEADER = "Location"
+private const val RESPOND_ASYNC = "respond-async"
+
+/** Interval between successive polls of the operations endpoint. Overridable for tests. */
+internal var POLL_INTERVAL: Duration = Duration.ofSeconds(1)
+
+/** Per-poll request timeout cap. */
+private val POLL_REQUEST_TIMEOUT: Duration = Duration.ofSeconds(60)
+
+/**
+ * Transparent polling for tpuf APIs that accept `prefer: respond-async`.
+ *
+ * Every outgoing request is stamped with `Prefer: respond-async`. If the server applies the
+ * preference (i.e. responds with `202 Accepted` + `Preference-Applied: respond-async`), this client
+ * polls the operation URL from the `Location` header until the operation finishes and returns the
+ * final response as if the call had been synchronous.
+ */
+class RespondAsyncHttpClient(
+    private val httpClient: HttpClient,
+    private val sleeper: Sleeper,
+    private val jsonMapper: JsonMapper,
+    private val clientHeaders: Headers,
+) : HttpClient {
+
+    override fun execute(request: HttpRequest, requestOptions: RequestOptions): HttpResponse {
+        val initialReq = prepareHeaders(request)
+        val initialRes = httpClient.execute(initialReq, requestOptions)
+        if (!respondAsyncApplied(initialRes)) {
+            return initialRes
+        }
+
+        val location = initialRes.use { extractLocation(it, initialReq.url()) }
+        val deadline = Deadline(requestOptions)
+        while (true) {
+            val pollReq = pollRequest(location)
+            val pollOpts = pollOptions(deadline)
+            val finalRes = httpClient.execute(pollReq, pollOpts).use { resolvePollResponse(it) }
+            if (finalRes != null) {
+                return finalRes
+            }
+            sleeper.sleep(deadline.sleepDuration())
+        }
+    }
+
+    override fun executeAsync(
+        request: HttpRequest,
+        requestOptions: RequestOptions,
+    ): CompletableFuture<HttpResponse> {
+        val initialReq = prepareHeaders(request)
+        return httpClient.executeAsync(initialReq, requestOptions).thenCompose { initialRes ->
+            if (!respondAsyncApplied(initialRes)) {
+                CompletableFuture.completedFuture(initialRes)
+            } else {
+                val location = initialRes.use { extractLocation(it, initialReq.url()) }
+                val deadline = Deadline(requestOptions)
+                pollAsync(location, deadline)
+            }
+        }
+    }
+
+    override fun close() = httpClient.close()
+
+    private fun pollAsync(location: String, deadline: Deadline): CompletableFuture<HttpResponse> {
+        val pollReq = pollRequest(location)
+        val pollOpts = pollOptions(deadline)
+        return httpClient.executeAsync(pollReq, pollOpts).thenCompose { resp ->
+            val finalRes = resp.use { resolvePollResponse(it) }
+            if (finalRes != null) {
+                CompletableFuture.completedFuture(finalRes)
+            } else {
+                sleeper.sleepAsync(deadline.sleepDuration()).thenCompose {
+                    pollAsync(location, deadline)
+                }
+            }
+        }
+    }
+
+    private fun prepareHeaders(request: HttpRequest): HttpRequest {
+        // Don't overwrite an existing `Prefer` header. Lets callers opt out per-request.
+        if (request.headers.names().contains(PREFER_HEADER)) {
+            return request
+        }
+        return request.toBuilder().putHeader(PREFER_HEADER, RESPOND_ASYNC).build()
+    }
+
+    private fun respondAsyncApplied(response: HttpResponse): Boolean {
+        if (response.statusCode() != 202) {
+            return false
+        }
+        val applied =
+            response.headers().values(PREFERENCE_APPLIED_HEADER).firstOrNull() ?: return false
+        return applied.trim().equals(RESPOND_ASYNC, ignoreCase = true)
+    }
+
+    /** Reads the `Location` header and resolves it against the given request URL. */
+    private fun extractLocation(response: HttpResponse, requestUrl: String): String {
+        val location =
+            response.headers().values(LOCATION_HEADER).firstOrNull()
+                ?: throw TurbopufferException(
+                    "server returned async response without a `Location` header"
+                )
+        return URI.create(requestUrl).resolve(location).toString()
+    }
+
+    private fun pollRequest(location: String): HttpRequest =
+        HttpRequest.builder()
+            .method(HttpMethod.GET)
+            .baseUrl(location)
+            .putAllHeaders(clientHeaders)
+            .build()
+
+    private fun pollOptions(deadline: Deadline): RequestOptions {
+        // Floor timeout at 1ms to avoid OkHttp's "0 means no timeout" semantics.
+        // https://square.github.io/okhttp/5.x/okhttp/okhttp3/-ok-http-client/-builder/call-timeout.html
+        val timeout = maxOf(Duration.ofMillis(1), deadline.pollTimeout())
+        return RequestOptions.builder().timeout(Timeout.builder().request(timeout).build()).build()
+    }
+
+    private fun resolvePollResponse(response: HttpResponse): HttpResponse? {
+        val body =
+            try {
+                jsonMapper.readValue(response.body(), PollBody::class.java)
+            } catch (t: Throwable) {
+                throw TurbopufferException("malformed poll response", t)
+            }
+        if (body.status == "running") return null
+        if (body.status != "finished" || body.result == null) {
+            throw TurbopufferException("malformed poll response")
+        }
+        val (success, error) = body.result
+        val (statusCode, payload) =
+            when {
+                success != null && error == null -> 200 to success
+                error != null && success == null -> error.statusCode to error.detail
+                else -> throw TurbopufferException("malformed poll response")
+            }
+
+        val bytes = jsonMapper.writeValueAsBytes(payload)
+        val headers = Headers.builder().put("Content-Type", "application/json").build()
+        return object : HttpResponse {
+            override fun statusCode(): Int = statusCode
+
+            override fun headers(): Headers = headers
+
+            override fun body(): InputStream = ByteArrayInputStream(bytes)
+
+            override fun close() {}
+        }
+    }
+}
+
+/** Tracks a polling-loop timeout. */
+private class Deadline(requestOptions: RequestOptions) {
+
+    private val deadlineNs: Long =
+        requestOptions.timeout?.request()?.let { System.nanoTime() + it.toNanos() }
+            ?: Long.MAX_VALUE
+
+    fun remaining(): Duration = Duration.ofNanos(maxOf(0L, deadlineNs - System.nanoTime()))
+
+    fun pollTimeout(): Duration = minOf(POLL_REQUEST_TIMEOUT, remaining())
+
+    fun sleepDuration(): Duration = minOf(POLL_INTERVAL, remaining())
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+private data class PollBody(val status: String, val result: PollResult? = null)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+private data class PollResult(val success: JsonNode? = null, val error: PollError? = null)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+private data class PollError(@JsonProperty("status_code") val statusCode: Int, val detail: JsonNode)

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
@@ -1,0 +1,423 @@
+package com.turbopuffer.core.http
+
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.absent
+import com.github.tomakehurst.wiremock.client.WireMock.containing
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.ok
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.resetAllScenarios
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.client.WireMock.verify
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import com.turbopuffer.client.okhttp.OkHttpClient
+import com.turbopuffer.core.RequestOptions
+import com.turbopuffer.core.Sleeper
+import com.turbopuffer.core.jsonMapper
+import com.turbopuffer.errors.TurbopufferException
+import com.turbopuffer.errors.TurbopufferIoException
+import java.io.InputStream
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionException
+import java.util.concurrent.ExecutionException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@WireMockTest
+@ResourceLock("https://github.com/wiremock/wiremock/issues/169")
+internal class RespondAsyncHttpClientTest {
+
+    private var openResponseCount = 0
+    private lateinit var baseUrl: String
+    private lateinit var delegate: HttpClient
+    private val jsonMapper: JsonMapper = jsonMapper()
+
+    private class RecordingSleeper : Sleeper {
+        var sleeps = 0
+            private set
+
+        override fun sleep(duration: Duration) {
+            sleeps++
+        }
+
+        override fun sleepAsync(duration: Duration): CompletableFuture<Void> {
+            sleeps++
+            return CompletableFuture.completedFuture(null)
+        }
+
+        override fun close() {}
+    }
+
+    @BeforeEach
+    fun beforeEach(wmRuntimeInfo: WireMockRuntimeInfo) {
+        POLL_INTERVAL = Duration.ZERO
+        baseUrl = wmRuntimeInfo.httpBaseUrl
+
+        val okHttpClient = OkHttpClient.builder().build()
+        delegate =
+            object : HttpClient {
+                override fun execute(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): HttpResponse = trackClose(okHttpClient.execute(request, requestOptions))
+
+                override fun executeAsync(
+                    request: HttpRequest,
+                    requestOptions: RequestOptions,
+                ): CompletableFuture<HttpResponse> =
+                    okHttpClient.executeAsync(request, requestOptions).thenApply { trackClose(it) }
+
+                override fun close() = okHttpClient.close()
+
+                private fun trackClose(response: HttpResponse): HttpResponse {
+                    openResponseCount++
+                    return object : HttpResponse {
+                        private var isClosed = false
+
+                        override fun statusCode(): Int = response.statusCode()
+
+                        override fun headers(): Headers = response.headers()
+
+                        override fun body(): InputStream = response.body()
+
+                        override fun close() {
+                            response.close()
+                            if (isClosed) {
+                                return
+                            }
+                            openResponseCount--
+                            isClosed = true
+                        }
+                    }
+                }
+            }
+
+        resetAllScenarios()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        POLL_INTERVAL = Duration.ofSeconds(1)
+        assertThat(openResponseCount).isEqualTo(0)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun sendsPreferHeader(async: Boolean) {
+        stubFor(post(urlPathEqualTo("/something")).willReturn(ok()))
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        client.execute(simplePost(), async).use {}
+
+        verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/something"))
+                .withHeader("Prefer", equalTo("respond-async")),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun passesThroughSyncResponse(async: Boolean) {
+        stubFor(post(urlPathEqualTo("/something")).willReturn(ok()))
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        client.execute(simplePost(), async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(200)
+        }
+
+        assertThat(sleeper.sleeps).isEqualTo(0)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun pollsUntilSuccess(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-abc")
+                        .withBody("ignored")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-abc"))
+                .inScenario("poll")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"running"}""")
+                )
+                .willSetStateTo("FINISHED")
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-abc"))
+                .inScenario("poll")
+                .whenScenarioStateIs("FINISHED")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"finished","result":{"success":{"foo":1}}}""")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        client.execute(simplePost(), async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(200)
+            assertThat(response.bodyAsString()).isEqualTo("""{"foo":1}""")
+        }
+
+        verify(
+            2,
+            getRequestedFor(urlPathEqualTo("/v1/namespaces/test/operations/op-abc"))
+                .withHeader("Prefer", absent()),
+        )
+        assertThat(sleeper.sleeps).isEqualTo(1)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun pollsUntilError(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-err")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-err"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """
+                            {"status":"finished","result":{"error":{"status_code":404,"detail":{"message":"namespace not found"}}}}
+                            """
+                                .trimIndent()
+                        )
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        client.execute(simplePost(), async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(404)
+            assertThat(response.bodyAsString()).isEqualTo("""{"message":"namespace not found"}""")
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun throwsOnMissingLocationHeader(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse().withStatus(202).withHeader("Preference-Applied", "respond-async")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        assertThatThrownBy { client.execute(simplePost(), async) }
+            .matches { unwrap(it) is TurbopufferException }
+            .hasMessageContaining("Location")
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun throwsOnMalformedPollBody(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-bad")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-bad"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"finished"}""")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        assertThatThrownBy { client.execute(simplePost(), async) }
+            .matches { unwrap(it) is TurbopufferException }
+            .hasMessageContaining("malformed poll response")
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun passesThroughUnrelated202(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(aResponse().withStatus(202).withBody("not-our-business"))
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        client.execute(simplePost(), async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(202)
+            assertThat(response.bodyAsString()).isEqualTo("not-our-business")
+        }
+
+        assertThat(sleeper.sleeps).isEqualTo(0)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun throwsOnPollTimeout(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-slow")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-slow"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"running"}""")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        val opts = RequestOptions.builder().timeout(Duration.ofSeconds(1)).build()
+
+        assertThatThrownBy {
+                if (async) client.executeAsync(simplePost(), opts).get()
+                else client.execute(simplePost(), opts)
+            }
+            .matches { unwrap(it) is TurbopufferIoException }
+            .hasMessageContaining("Request failed")
+        assertThat(sleeper.sleeps).isGreaterThan(0)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun retainsCallerSuppliedPreferHeader(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .withHeader("Prefer", containing("wait=10"))
+                .willReturn(ok())
+        )
+        val client = respondAsyncClient(RecordingSleeper())
+
+        val request =
+            HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .baseUrl(baseUrl)
+                .addPathSegment("something")
+                .putHeader("Prefer", "wait=10")
+                .build()
+
+        client.execute(request, async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(200)
+        }
+
+        verify(
+            1,
+            postRequestedFor(urlPathEqualTo("/something")).withHeader("Prefer", equalTo("wait=10")),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
+    fun pollUsesClientHeadersNotRequestHeaders(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-headers")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-headers"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"finished","result":{"success":{}}}""")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val clientHeaders = Headers.builder().put("Authorization", "Bearer client-key").build()
+        val client = RespondAsyncHttpClient(delegate, sleeper, jsonMapper, clientHeaders)
+
+        val request =
+            HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .baseUrl(baseUrl)
+                .addPathSegment("something")
+                .putHeader("X-Per-Request", "hello")
+                .build()
+
+        client.execute(request, async).use {}
+
+        verify(
+            1,
+            getRequestedFor(urlPathEqualTo("/v1/namespaces/test/operations/op-headers"))
+                .withHeader("Authorization", equalTo("Bearer client-key"))
+                .withHeader("X-Per-Request", absent()),
+        )
+    }
+
+    private fun respondAsyncClient(sleeper: RecordingSleeper): RespondAsyncHttpClient =
+        RespondAsyncHttpClient(delegate, sleeper, jsonMapper, Headers.builder().build())
+
+    private fun simplePost(): HttpRequest =
+        HttpRequest.builder()
+            .method(HttpMethod.POST)
+            .baseUrl(baseUrl)
+            .addPathSegment("something")
+            .build()
+
+    private fun HttpClient.execute(request: HttpRequest, async: Boolean): HttpResponse =
+        if (async) executeAsync(request).get() else execute(request)
+
+    private fun HttpResponse.bodyAsString(): String =
+        body().use { it.readBytes().toString(Charsets.UTF_8) }
+
+    private fun unwrap(t: Throwable): Throwable =
+        if ((t is CompletionException || t is ExecutionException) && t.cause != null) t.cause!!
+        else t
+}


### PR DESCRIPTION
This adds support for transparent async polling against tpuf APIs that support it. The SDK unconditionally set the `Prefer: respond-async` header on all API calls, then detects and handles async responses by polling them until the final state.