### PR TITLE
fix: no async polling deadline on zero timeout

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
@@ -170,9 +170,12 @@ class RespondAsyncHttpClient(
 /** Tracks a polling-loop timeout. */
 private class Deadline(requestOptions: RequestOptions) {
 
-    private val deadlineNs: Long =
-        requestOptions.timeout?.request()?.let { System.nanoTime() + it.toNanos() }
-            ?: Long.MAX_VALUE
+    // `Timeout.request()` uses `Duration.ZERO` to mean "no timeout".
+    private val deadlineNs: Long = run {
+        val request = requestOptions.timeout?.request()
+        if (request == null || request.isZero) Long.MAX_VALUE
+        else System.nanoTime() + request.toNanos()
+    }
 
     fun remaining(): Duration = Duration.ofNanos(maxOf(0L, deadlineNs - System.nanoTime()))
 

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.stubbing.Scenario
 import com.turbopuffer.client.okhttp.OkHttpClient
 import com.turbopuffer.core.RequestOptions
 import com.turbopuffer.core.Sleeper
+import com.turbopuffer.core.Timeout
 import com.turbopuffer.core.jsonMapper
 import com.turbopuffer.errors.TurbopufferException
 import com.turbopuffer.errors.TurbopufferIoException
@@ -332,6 +333,56 @@ internal class RespondAsyncHttpClientTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [false, true])
+    fun zeroRequestTimeoutMeansNoDeadline(async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", "/v1/namespaces/test/operations/op-zero")
+                )
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-zero"))
+                .inScenario("poll-zero")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"running"}""")
+                )
+                .willSetStateTo("FINISHED")
+        )
+        stubFor(
+            get(urlPathEqualTo("/v1/namespaces/test/operations/op-zero"))
+                .inScenario("poll-zero")
+                .whenScenarioStateIs("FINISHED")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""{"status":"finished","result":{"success":{"ok":true}}}""")
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        val opts =
+            RequestOptions.builder()
+                .timeout(Timeout.builder().request(Duration.ZERO).build())
+                .build()
+
+        client.execute(simplePost(), opts, async).use { response ->
+            assertThat(response.statusCode()).isEqualTo(200)
+            assertThat(response.bodyAsString()).isEqualTo("""{"ok":true}""")
+        }
+        assertThat(sleeper.sleeps).isEqualTo(1)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [false, true])
     fun retainsCallerSuppliedPreferHeader(async: Boolean) {
         stubFor(
             post(urlPathEqualTo("/something"))
@@ -413,6 +464,12 @@ internal class RespondAsyncHttpClientTest {
 
     private fun HttpClient.execute(request: HttpRequest, async: Boolean): HttpResponse =
         if (async) executeAsync(request).get() else execute(request)
+
+    private fun HttpClient.execute(
+        request: HttpRequest,
+        opts: RequestOptions,
+        async: Boolean,
+    ): HttpResponse = if (async) executeAsync(request, opts).get() else execute(request, opts)
 
     private fun HttpResponse.bodyAsString(): String =
         body().use { it.readBytes().toString(Charsets.UTF_8) }


### PR DESCRIPTION
The `Timeout` class documents that a timeout value of `Duration.ZERO` means "no timeout". This requires special treatment in the `Deadline` class used by async polling, which would otherwise interpret a zero timeout as "a timeout after zero nanoseconds".

[Found by bugbot on the release PR.](https://github.com/turbopuffer/turbopuffer-java/pull/231#discussion_r3316471785)