### PR TITLE
fix: reject malicious poll locations

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
@@ -125,16 +125,25 @@ class RespondAsyncHttpClient(
                 throw TurbopufferException("malformed `Location` header: $rawLocation", e)
             }
         // Reject a Location pointing at a different origin, to prevent API key exfiltration.
-        if (
-            resolved.scheme != origUri.scheme ||
-                resolved.host != origUri.host ||
-                resolved.port != origUri.port
-        ) {
+        if (origin(resolved) != origin(origUri)) {
             throw TurbopufferException(
                 "`Location` origin does not match request origin: $rawLocation"
             )
         }
         return resolved.toString()
+    }
+
+    /** `(scheme, host, port)` triple with the scheme's default port substituted when omitted. */
+    private fun origin(uri: URI): Triple<String?, String?, Int> {
+        val port =
+            if (uri.port != -1) uri.port
+            else
+                when (uri.scheme) {
+                    "http" -> 80
+                    "https" -> 443
+                    else -> -1
+                }
+        return Triple(uri.scheme, uri.host, port)
     }
 
     private fun pollRequest(location: String): HttpRequest =

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClient.kt
@@ -112,12 +112,29 @@ class RespondAsyncHttpClient(
 
     /** Reads the `Location` header and resolves it against the given request URL. */
     private fun extractLocation(response: HttpResponse, requestUrl: String): String {
-        val location =
+        val rawLocation =
             response.headers().values(LOCATION_HEADER).firstOrNull()
                 ?: throw TurbopufferException(
                     "server returned async response without a `Location` header"
                 )
-        return URI.create(requestUrl).resolve(location).toString()
+        val origUri = URI.create(requestUrl)
+        val resolved =
+            try {
+                origUri.resolve(rawLocation)
+            } catch (e: IllegalArgumentException) {
+                throw TurbopufferException("malformed `Location` header: $rawLocation", e)
+            }
+        // Reject a Location pointing at a different origin, to prevent API key exfiltration.
+        if (
+            resolved.scheme != origUri.scheme ||
+                resolved.host != origUri.host ||
+                resolved.port != origUri.port
+        ) {
+            throw TurbopufferException(
+                "`Location` origin does not match request origin: $rawLocation"
+            )
+        }
+        return resolved.toString()
     }
 
     private fun pollRequest(location: String): HttpRequest =

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/core/http/RespondAsyncHttpClientTest.kt
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.parallel.ResourceLock
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
 
 @WireMockTest
@@ -247,6 +249,27 @@ internal class RespondAsyncHttpClientTest {
         assertThatThrownBy { client.execute(simplePost(), async) }
             .matches { unwrap(it) is TurbopufferException }
             .hasMessageContaining("Location")
+    }
+
+    @ParameterizedTest
+    @MethodSource("badLocationArgs")
+    fun rejectsBadLocation(badLocation: String, async: Boolean) {
+        stubFor(
+            post(urlPathEqualTo("/something"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(202)
+                        .withHeader("Preference-Applied", "respond-async")
+                        .withHeader("Location", badLocation)
+                )
+        )
+        val sleeper = RecordingSleeper()
+        val client = respondAsyncClient(sleeper)
+
+        assertThatThrownBy { client.execute(simplePost(), async) }
+            .matches { unwrap(it) is TurbopufferException }
+            .hasMessageContaining("Location")
+        assertThat(sleeper.sleeps).isEqualTo(0)
     }
 
     @ParameterizedTest
@@ -477,4 +500,20 @@ internal class RespondAsyncHttpClientTest {
     private fun unwrap(t: Throwable): Throwable =
         if ((t is CompletionException || t is ExecutionException) && t.cause != null) t.cause!!
         else t
+
+    companion object {
+        @JvmStatic
+        fun badLocationArgs(): List<Arguments> {
+            val badLocations =
+                listOf(
+                    "https://evil.example.com/v1/ops/op-x",
+                    "//evil.example.com/v1/ops/op-x",
+                    "http://api.turbopuffer.com/v1/ops/op-x",
+                    "http://host:notaport/x",
+                )
+            return badLocations.flatMap { loc ->
+                listOf(Arguments.of(loc, false), Arguments.of(loc, true))
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes a minor security issue where the client wouldn't check the origin of the async response `Location` header before starting to poll it, allowing a man-in-the-middle to send poll requests (including API credentials) to arbitrary locations. This is a minor security issue, as such a man-in-the-middle would likely already know the API credentials from observing the initial authenticated request.

The fix is to compare the poll origin with the one from the original request, and reject if they differ.