### PR TITLE
fix: type rerank_by parameter as RerankBy

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
@@ -51,12 +51,17 @@ private constructor(
     /**
      * How to combine the rows returned by each sub-query into a single ranked list.
      *
-     * This arbitrary value can be deserialized into a custom type using the `convert` method:
-     * ```java
-     * MyClass myObject = namespaceMultiQueryParams.rerankBy().convert(MyClass.class);
-     * ```
+     * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if the
+     *   server responded with an unexpected value).
      */
-    fun _rerankBy(): JsonValue = body._rerankBy()
+    fun rerankBy(): Optional<RerankBy> = body.rerankBy()
+
+    /**
+     * How to combine the rows returned by each sub-query into a single ranked list.
+     *
+     * Unlike [rerankBy], this method doesn't throw if the JSON field has an unexpected type.
+     */
+    fun _rerankBy(): JsonField<RerankBy> = body._rerankBy()
 
     /**
      * The encoding to use for vectors in the response.
@@ -176,7 +181,16 @@ private constructor(
         }
 
         /** How to combine the rows returned by each sub-query into a single ranked list. */
-        fun rerankBy(rerankBy: JsonValue) = apply { body.rerankBy(rerankBy) }
+        fun rerankBy(rerankBy: RerankBy) = apply { body.rerankBy(rerankBy) }
+
+        /**
+         * Sets [Builder.rerankBy] to an arbitrary JSON value.
+         *
+         * You should usually call [Builder.rerankBy] with a well-typed [RerankBy] value instead.
+         * This method is primarily for setting the field to an undocumented or not yet supported
+         * value.
+         */
+        fun rerankBy(rerankBy: JsonField<RerankBy>) = apply { body.rerankBy(rerankBy) }
 
         /** The encoding to use for vectors in the response. */
         fun vectorEncoding(vectorEncoding: VectorEncoding) = apply {
@@ -350,7 +364,7 @@ private constructor(
     private constructor(
         private val queries: JsonField<List<Query>>,
         private val consistency: JsonField<Consistency>,
-        private val rerankBy: JsonValue,
+        private val rerankBy: JsonField<RerankBy>,
         private val vectorEncoding: JsonField<VectorEncoding>,
         private val additionalProperties: MutableMap<String, JsonValue>,
     ) {
@@ -363,7 +377,9 @@ private constructor(
             @JsonProperty("consistency")
             @ExcludeMissing
             consistency: JsonField<Consistency> = JsonMissing.of(),
-            @JsonProperty("rerank_by") @ExcludeMissing rerankBy: JsonValue = JsonMissing.of(),
+            @JsonProperty("rerank_by")
+            @ExcludeMissing
+            rerankBy: JsonField<RerankBy> = JsonMissing.of(),
             @JsonProperty("vector_encoding")
             @ExcludeMissing
             vectorEncoding: JsonField<VectorEncoding> = JsonMissing.of(),
@@ -386,12 +402,18 @@ private constructor(
         /**
          * How to combine the rows returned by each sub-query into a single ranked list.
          *
-         * This arbitrary value can be deserialized into a custom type using the `convert` method:
-         * ```java
-         * MyClass myObject = body.rerankBy().convert(MyClass.class);
-         * ```
+         * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if
+         *   the server responded with an unexpected value).
          */
-        @JsonProperty("rerank_by") @ExcludeMissing fun _rerankBy(): JsonValue = rerankBy
+        fun rerankBy(): Optional<RerankBy> = rerankBy.getOptional("rerank_by")
+
+        /**
+         * How to combine the rows returned by each sub-query into a single ranked list.
+         *
+         * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if
+         *   the server responded with an unexpected value).
+         */
+        @JsonProperty("rerank_by") @ExcludeMissing fun _rerankBy(): JsonField<RerankBy> = rerankBy
 
         /**
          * The encoding to use for vectors in the response.
@@ -458,7 +480,7 @@ private constructor(
 
             private var queries: JsonField<MutableList<Query>>? = null
             private var consistency: JsonField<Consistency> = JsonMissing.of()
-            private var rerankBy: JsonValue = JsonMissing.of()
+            private var rerankBy: JsonField<RerankBy> = JsonMissing.of()
             private var vectorEncoding: JsonField<VectorEncoding> = JsonMissing.of()
             private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
 
@@ -511,7 +533,16 @@ private constructor(
             }
 
             /** How to combine the rows returned by each sub-query into a single ranked list. */
-            fun rerankBy(rerankBy: JsonValue) = apply { this.rerankBy = rerankBy }
+            fun rerankBy(rerankBy: RerankBy) = rerankBy(JsonField.of(rerankBy))
+
+            /**
+             * Sets [Builder.rerankBy] to an arbitrary JSON value.
+             *
+             * You should usually call [Builder.rerankBy] with a well-typed [RerankBy] value
+             * instead. This method is primarily for setting the field to an undocumented or not yet
+             * supported value.
+             */
+            fun rerankBy(rerankBy: JsonField<RerankBy>) = apply { this.rerankBy = rerankBy }
 
             /** The encoding to use for vectors in the response. */
             fun vectorEncoding(vectorEncoding: VectorEncoding) =


### PR DESCRIPTION
## Summary
- Stainless leaves the `rerankBy` field typed as `JsonValue`. This wires it to the already-generated `RerankBy` sealed class using the same `JsonField<RerankBy>` pattern as `rank_by` — both a well-typed setter and an arbitrary-JSON overload.

## Test plan
- [x] `:turbopuffer-java-core:compileKotlin` passes
- [x] Existing test calls (`.rerankBy(JsonValue.from(...))`) still type-check via `JsonValue : JsonField<Nothing>` covariance, matching how `rank_by` is tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)