### PR TITLE
chore: fix import ordering in generated tests

### DIFF
--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/ServiceParamsTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/ServiceParamsTest.kt
@@ -25,8 +25,8 @@ import com.turbopuffer.models.namespaces.Encryption
 import com.turbopuffer.models.namespaces.Filter
 import com.turbopuffer.models.namespaces.NamespaceWriteParams
 import com.turbopuffer.models.namespaces.Row
-import com.turbopuffer.models.namespaces.ShardingConfig
 import com.turbopuffer.models.namespaces.Schema
+import com.turbopuffer.models.namespaces.ShardingConfig
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
@@ -24,8 +24,8 @@ import com.turbopuffer.models.namespaces.NamespaceUpdateMetadataParams
 import com.turbopuffer.models.namespaces.NamespaceUpdateSchemaParams
 import com.turbopuffer.models.namespaces.NamespaceWriteParams
 import com.turbopuffer.models.namespaces.Row
-import com.turbopuffer.models.namespaces.ShardingConfig
 import com.turbopuffer.models.namespaces.Schema
+import com.turbopuffer.models.namespaces.ShardingConfig
 import com.turbopuffer.models.namespaces.VectorEncoding
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
@@ -24,8 +24,8 @@ import com.turbopuffer.models.namespaces.NamespaceUpdateMetadataParams
 import com.turbopuffer.models.namespaces.NamespaceUpdateSchemaParams
 import com.turbopuffer.models.namespaces.NamespaceWriteParams
 import com.turbopuffer.models.namespaces.Row
-import com.turbopuffer.models.namespaces.ShardingConfig
 import com.turbopuffer.models.namespaces.Schema
+import com.turbopuffer.models.namespaces.ShardingConfig
 import com.turbopuffer.models.namespaces.VectorEncoding
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
The generator inserted the `ShardingConfig` import before `Schema` in three test files, which fails the ktfmt lint check on `next` and blocks the 2.5.0 release PR (#246).

Ran `scripts/gen` + `./gradlew formatKotlin formatJava`; this import reorder is the only resulting diff (`CustomTypes.kt` regenerated identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)