### PR TITLE
chore: regenerate custom types for compute attributes

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/CustomTypes.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/CustomTypes.kt
@@ -94,6 +94,100 @@ class AggregateBySum private constructor(attr: String) : AggregateBy() {
     }
 }
 
+@JsonDeserialize(using = ComputeAttributes.Deserializer::class)
+sealed class ComputeAttributes() {
+    companion object {
+        @JvmStatic
+        public fun vectorDist(attr: String, value: List<Float>): ComputeAttributesVectorDist =
+            ComputeAttributesVectorDist.create(attr, value)
+
+        @JvmStatic
+        public fun highlight(attr: String): ComputeAttributesHighlight =
+            ComputeAttributesHighlight.create(attr)
+
+        @JvmStatic
+        public fun highlight(
+            attr: String,
+            config: HighlightConfigParams,
+        ): ComputeAttributesHighlightWithConfig =
+            ComputeAttributesHighlightWithConfig.create(attr, config)
+    }
+
+    class Deserializer : BaseDeserializer<ComputeAttributes>(ComputeAttributes::class) {
+        override fun ObjectCodec.deserialize(node: JsonNode): ComputeAttributes {
+            return ComputeAttributesRaw(JsonValue.fromJsonNode(node))
+        }
+    }
+}
+
+class ComputeAttributesRaw internal constructor(value: JsonValue) : ComputeAttributes() {
+    @JsonValueAnnotation private val value: JsonValue = value
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(value)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("f0", "attr")
+class ComputeAttributesHighlight private constructor(attr: String) : ComputeAttributes() {
+    private val f0: String = "Highlight"
+    private val attr: String = attr
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(attr: String): ComputeAttributesHighlight =
+            ComputeAttributesHighlight(attr)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("f0", "attr", "config")
+class ComputeAttributesHighlightWithConfig
+private constructor(attr: String, config: HighlightConfigParams) : ComputeAttributes() {
+    private val f0: String = "Highlight"
+    private val attr: String = attr
+    private val config: HighlightConfigParams = config
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(
+            attr: String,
+            config: HighlightConfigParams,
+        ): ComputeAttributesHighlightWithConfig = ComputeAttributesHighlightWithConfig(attr, config)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("attr", "f0", "value")
+class ComputeAttributesVectorDist private constructor(attr: String, value: List<Float>) :
+    ComputeAttributes() {
+    private val attr: String = attr
+    private val f0: String = "VectorDist"
+    private val value: List<Float> = value
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(attr: String, value: List<Float>): ComputeAttributesVectorDist =
+            ComputeAttributesVectorDist(attr, value)
+    }
+}
+
 @JsonDeserialize(using = Expr.Deserializer::class)
 sealed class Expr() {
     companion object {
@@ -1091,7 +1185,7 @@ class GroupByFunctionForEachUnique private constructor(attr: String) : GroupByFu
 }
 
 @JsonDeserialize(using = RankBy.Deserializer::class)
-sealed class RankBy() {
+sealed class RankBy() : ComputeAttributes() {
     companion object {
         @JvmStatic
         public fun ann(attr: String, value: List<Float>): RankByAnn = RankByAnn.create(attr, value)

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceExplainQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceExplainQueryParams.kt
@@ -1216,7 +1216,6 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
             computeAttributes().ifPresent { it.validate() }
             consistency().ifPresent { it.validate() }
@@ -1299,7 +1298,6 @@ private constructor(
         override fun toString() =
             "Body{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, consistency=$consistency, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, vectorEncoding=$vectorEncoding, additionalProperties=$additionalProperties}"
     }
-
 
     /**
      * Computes additional values on documents returned by a query. Each key is the name of the

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
@@ -1192,7 +1192,6 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
             computeAttributes().ifPresent { it.validate() }
             distanceMetric().ifPresent { it.validate() }
@@ -1227,7 +1226,6 @@ private constructor(
                 (includeAttributes.asKnown().getOrNull()?.validity() ?: 0) +
                 (limit.asKnown().getOrNull()?.validity() ?: 0) +
                 (if (topK.asKnown().isPresent) 1 else 0)
-
 
         override fun equals(other: Any?): Boolean {
             if (this === other) {
@@ -1268,6 +1266,7 @@ private constructor(
 
         override fun toString() =
             "Query{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, additionalProperties=$additionalProperties}"
+
         /**
          * Computes additional values on documents returned by a query. Each key is the name of the
          * computed attribute; each value is an expression describing how to compute it.
@@ -1388,7 +1387,6 @@ private constructor(
             override fun toString() =
                 "ComputeAttributes{additionalProperties=$additionalProperties}"
         }
-
     }
 
     /** The consistency level for a query. */

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceQueryParams.kt
@@ -1209,7 +1209,6 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
             computeAttributes().ifPresent { it.validate() }
             consistency().ifPresent { it.validate() }
@@ -1292,7 +1291,6 @@ private constructor(
         override fun toString() =
             "Body{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, consistency=$consistency, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, vectorEncoding=$vectorEncoding, additionalProperties=$additionalProperties}"
     }
-
 
     /**
      * Computes additional values on documents returned by a query. Each key is the name of the

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
@@ -98,7 +98,6 @@ internal class NamespaceServiceAsyncTest {
             namespaceServiceAsync.explainQuery(
                 NamespaceExplainQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)
@@ -152,7 +151,6 @@ internal class NamespaceServiceAsyncTest {
                     .namespace("namespace")
                     .addQuery(
                         NamespaceMultiQueryParams.Query.builder()
-
                             .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                             .addExcludeAttribute("string")
                             .includeAttributes(true)
@@ -184,7 +182,6 @@ internal class NamespaceServiceAsyncTest {
             namespaceServiceAsync.query(
                 NamespaceQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
@@ -95,7 +95,6 @@ internal class NamespaceServiceTest {
             namespaceService.explainQuery(
                 NamespaceExplainQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)
@@ -145,7 +144,6 @@ internal class NamespaceServiceTest {
                     .namespace("namespace")
                     .addQuery(
                         NamespaceMultiQueryParams.Query.builder()
-
                             .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                             .addExcludeAttribute("string")
                             .includeAttributes(true)
@@ -176,7 +174,6 @@ internal class NamespaceServiceTest {
             namespaceService.query(
                 NamespaceQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)


### PR DESCRIPTION
Lands the apigen-generated `ComputeAttributes` union into `CustomTypes.kt` (regen workflow can't push to next due to the branch ruleset — same PR path as go/python/csharp/ts).

Verified locally with JDK 21: `compileKotlin` + `compileTestKotlin` succeed; `formatKotlin` idempotent so the out-of-date lint passes.