### PR TITLE
spec: using typed version of `ComputeAttributes` for `compute_attributes`

### DIFF
--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/CustomTypes.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/CustomTypes.kt
@@ -94,6 +94,100 @@ class AggregateBySum private constructor(attr: String) : AggregateBy() {
     }
 }
 
+@JsonDeserialize(using = ComputeAttributes.Deserializer::class)
+sealed class ComputeAttributes() {
+    companion object {
+        @JvmStatic
+        public fun vectorDist(attr: String, value: List<Float>): ComputeAttributesVectorDist =
+            ComputeAttributesVectorDist.create(attr, value)
+
+        @JvmStatic
+        public fun highlight(attr: String): ComputeAttributesHighlight =
+            ComputeAttributesHighlight.create(attr)
+
+        @JvmStatic
+        public fun highlight(
+            attr: String,
+            config: HighlightConfigParams,
+        ): ComputeAttributesHighlightWithConfig =
+            ComputeAttributesHighlightWithConfig.create(attr, config)
+    }
+
+    class Deserializer : BaseDeserializer<ComputeAttributes>(ComputeAttributes::class) {
+        override fun ObjectCodec.deserialize(node: JsonNode): ComputeAttributes {
+            return ComputeAttributesRaw(JsonValue.fromJsonNode(node))
+        }
+    }
+}
+
+class ComputeAttributesRaw internal constructor(value: JsonValue) : ComputeAttributes() {
+    @JsonValueAnnotation private val value: JsonValue = value
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(value)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("f0", "attr")
+class ComputeAttributesHighlight private constructor(attr: String) : ComputeAttributes() {
+    private val f0: String = "Highlight"
+    private val attr: String = attr
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(attr: String): ComputeAttributesHighlight =
+            ComputeAttributesHighlight(attr)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("f0", "attr", "config")
+class ComputeAttributesHighlightWithConfig
+private constructor(attr: String, config: HighlightConfigParams) : ComputeAttributes() {
+    private val f0: String = "Highlight"
+    private val attr: String = attr
+    private val config: HighlightConfigParams = config
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(
+            attr: String,
+            config: HighlightConfigParams,
+        ): ComputeAttributesHighlightWithConfig = ComputeAttributesHighlightWithConfig(attr, config)
+    }
+}
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+@JsonPropertyOrder("attr", "f0", "value")
+class ComputeAttributesVectorDist private constructor(attr: String, value: List<Float>) :
+    ComputeAttributes() {
+    private val attr: String = attr
+    private val f0: String = "VectorDist"
+    private val value: List<Float> = value
+
+    override fun toString(): String {
+        return jsonMapper.writeValueAsString(this)
+    }
+
+    companion object {
+        @JvmSynthetic
+        internal fun create(attr: String, value: List<Float>): ComputeAttributesVectorDist =
+            ComputeAttributesVectorDist(attr, value)
+    }
+}
+
 @JsonDeserialize(using = Expr.Deserializer::class)
 sealed class Expr() {
     companion object {
@@ -1091,7 +1185,7 @@ class GroupByFunctionForEachUnique private constructor(attr: String) : GroupByFu
 }
 
 @JsonDeserialize(using = RankBy.Deserializer::class)
-sealed class RankBy() {
+sealed class RankBy() : ComputeAttributes() {
     companion object {
         @JvmStatic
         public fun ann(attr: String, value: List<Float>): RankByAnn = RankByAnn.create(attr, value)

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceExplainQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceExplainQueryParams.kt
@@ -48,7 +48,8 @@ private constructor(
      * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if the
      *   server responded with an unexpected value).
      */
-    fun computeAttributes(): Optional<ComputeAttributes> = body.computeAttributes()
+    fun computeAttributes(): Optional<MutableMap<String, ComputeAttributes>> =
+        body.computeAttributes()
 
     /**
      * The consistency level for a query.
@@ -161,7 +162,8 @@ private constructor(
      * Unlike [computeAttributes], this method doesn't throw if the JSON field has an unexpected
      * type.
      */
-    fun _computeAttributes(): JsonField<ComputeAttributes> = body._computeAttributes()
+    fun _computeAttributes(): JsonField<MutableMap<String, ComputeAttributes>> =
+        body._computeAttributes()
 
     /**
      * Returns the raw JSON value of [consistency].
@@ -296,7 +298,7 @@ private constructor(
          * Computes additional values on documents returned by a query. Each key is the name of the
          * computed attribute; each value is an expression describing how to compute it.
          */
-        fun computeAttributes(computeAttributes: ComputeAttributes) = apply {
+        fun computeAttributes(computeAttributes: MutableMap<String, ComputeAttributes>) = apply {
             body.computeAttributes(computeAttributes)
         }
 
@@ -307,9 +309,10 @@ private constructor(
          * value instead. This method is primarily for setting the field to an undocumented or not
          * yet supported value.
          */
-        fun computeAttributes(computeAttributes: JsonField<ComputeAttributes>) = apply {
-            body.computeAttributes(computeAttributes)
-        }
+        fun computeAttributes(computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>) =
+            apply {
+                body.computeAttributes(computeAttributes)
+            }
 
         /** The consistency level for a query. */
         fun consistency(consistency: Consistency) = apply { body.consistency(consistency) }
@@ -613,7 +616,7 @@ private constructor(
     @JsonCreator(mode = JsonCreator.Mode.DISABLED)
     private constructor(
         private val aggregateBy: JsonField<MutableMap<String, AggregateBy>>,
-        private val computeAttributes: JsonField<ComputeAttributes>,
+        private val computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>,
         private val consistency: JsonField<Consistency>,
         private val distanceMetric: JsonField<DistanceMetric>,
         private val excludeAttributes: JsonField<List<String>>,
@@ -634,7 +637,7 @@ private constructor(
             aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of(),
             @JsonProperty("compute_attributes")
             @ExcludeMissing
-            computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of(),
+            computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> = JsonMissing.of(),
             @JsonProperty("consistency")
             @ExcludeMissing
             consistency: JsonField<Consistency> = JsonMissing.of(),
@@ -689,7 +692,7 @@ private constructor(
          * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if
          *   the server responded with an unexpected value).
          */
-        fun computeAttributes(): Optional<ComputeAttributes> =
+        fun computeAttributes(): Optional<MutableMap<String, ComputeAttributes>> =
             computeAttributes.getOptional("compute_attributes")
 
         /**
@@ -812,7 +815,8 @@ private constructor(
          */
         @JsonProperty("compute_attributes")
         @ExcludeMissing
-        fun _computeAttributes(): JsonField<ComputeAttributes> = computeAttributes
+        fun _computeAttributes(): JsonField<MutableMap<String, ComputeAttributes>> =
+            computeAttributes
 
         /**
          * Returns the raw JSON value of [consistency].
@@ -906,7 +910,8 @@ private constructor(
         class Builder internal constructor() {
 
             private var aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of()
-            private var computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of()
+            private var computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> =
+                JsonMissing.of()
             private var consistency: JsonField<Consistency> = JsonMissing.of()
             private var distanceMetric: JsonField<DistanceMetric> = JsonMissing.of()
             private var excludeAttributes: JsonField<MutableList<String>>? = null
@@ -957,19 +962,19 @@ private constructor(
              * Computes additional values on documents returned by a query. Each key is the name of
              * the computed attribute; each value is an expression describing how to compute it.
              */
-            fun computeAttributes(computeAttributes: ComputeAttributes) =
+            fun computeAttributes(computeAttributes: MutableMap<String, ComputeAttributes>) =
                 computeAttributes(JsonField.of(computeAttributes))
 
             /**
              * Sets [Builder.computeAttributes] to an arbitrary JSON value.
              *
              * You should usually call [Builder.computeAttributes] with a well-typed
-             * [ComputeAttributes] value instead. This method is primarily for setting the field to
-             * an undocumented or not yet supported value.
+             * `MutableMap<String, ComputeAttributes>` value instead. This method is primarily for
+             * setting the field to an undocumented or not yet supported value.
              */
-            fun computeAttributes(computeAttributes: JsonField<ComputeAttributes>) = apply {
-                this.computeAttributes = computeAttributes
-            }
+            fun computeAttributes(
+                computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>
+            ) = apply { this.computeAttributes = computeAttributes }
 
             /** The consistency level for a query. */
             fun consistency(consistency: Consistency) = consistency(JsonField.of(consistency))
@@ -1216,9 +1221,8 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
-            computeAttributes().ifPresent { it.validate() }
+            computeAttributes()
             consistency().ifPresent { it.validate() }
             distanceMetric().ifPresent { it.validate() }
             excludeAttributes()
@@ -1247,6 +1251,7 @@ private constructor(
         @JvmSynthetic
         internal fun validity(): Int =
             (if (aggregateBy.asKnown().isPresent()) 1 else 0) +
+                (if (computeAttributes.asKnown().isPresent()) 1 else 0) +
                 (consistency.asKnown().getOrNull()?.validity() ?: 0) +
                 (distanceMetric.asKnown().getOrNull()?.validity() ?: 0) +
                 (excludeAttributes.asKnown().getOrNull()?.size ?: 0) +
@@ -1298,119 +1303,6 @@ private constructor(
 
         override fun toString() =
             "Body{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, consistency=$consistency, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, vectorEncoding=$vectorEncoding, additionalProperties=$additionalProperties}"
-    }
-
-
-    /**
-     * Computes additional values on documents returned by a query. Each key is the name of the
-     * computed attribute; each value is an expression describing how to compute it.
-     */
-    class ComputeAttributes
-    @JsonCreator
-    private constructor(
-        @com.fasterxml.jackson.annotation.JsonValue
-        private val additionalProperties: Map<String, JsonValue>
-    ) {
-
-        @JsonAnyGetter
-        @ExcludeMissing
-        fun _additionalProperties(): Map<String, JsonValue> = additionalProperties
-
-        fun toBuilder() = Builder().from(this)
-
-        companion object {
-
-            /** Returns a mutable builder for constructing an instance of [ComputeAttributes]. */
-            @JvmStatic fun builder() = Builder()
-        }
-
-        /** A builder for [ComputeAttributes]. */
-        class Builder internal constructor() {
-
-            private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
-
-            @JvmSynthetic
-            internal fun from(computeAttributes: ComputeAttributes) = apply {
-                additionalProperties = computeAttributes.additionalProperties.toMutableMap()
-            }
-
-            fun additionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
-                this.additionalProperties.clear()
-                putAllAdditionalProperties(additionalProperties)
-            }
-
-            fun putAdditionalProperty(key: String, value: JsonValue) = apply {
-                additionalProperties.put(key, value)
-            }
-
-            fun putAllAdditionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
-                this.additionalProperties.putAll(additionalProperties)
-            }
-
-            fun removeAdditionalProperty(key: String) = apply { additionalProperties.remove(key) }
-
-            fun removeAllAdditionalProperties(keys: Set<String>) = apply {
-                keys.forEach(::removeAdditionalProperty)
-            }
-
-            /**
-             * Returns an immutable instance of [ComputeAttributes].
-             *
-             * Further updates to this [Builder] will not mutate the returned instance.
-             */
-            fun build(): ComputeAttributes = ComputeAttributes(additionalProperties.toImmutable())
-        }
-
-        private var validated: Boolean = false
-
-        /**
-         * Validates that the types of all values in this object match their expected types
-         * recursively.
-         *
-         * This method is _not_ forwards compatible with new types from the API for existing fields.
-         *
-         * @throws TurbopufferInvalidDataException if any value type in this object doesn't match
-         *   its expected type.
-         */
-        fun validate(): ComputeAttributes = apply {
-            if (validated) {
-                return@apply
-            }
-
-            validated = true
-        }
-
-        fun isValid(): Boolean =
-            try {
-                validate()
-                true
-            } catch (e: TurbopufferInvalidDataException) {
-                false
-            }
-
-        /**
-         * Returns a score indicating how many valid values are contained in this object
-         * recursively.
-         *
-         * Used for best match union deserialization.
-         */
-        @JvmSynthetic
-        internal fun validity(): Int =
-            additionalProperties.count { (_, value) -> !value.isNull() && !value.isMissing() }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) {
-                return true
-            }
-
-            return other is ComputeAttributes && additionalProperties == other.additionalProperties
-        }
-
-        private val hashCode: Int by lazy { Objects.hash(additionalProperties) }
-
-        override fun hashCode(): Int = hashCode
-
-        override fun toString() = "ComputeAttributes{additionalProperties=$additionalProperties}"
     }
 
     /** The consistency level for a query. */

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceMultiQueryParams.kt
@@ -670,7 +670,7 @@ private constructor(
     @JsonCreator(mode = JsonCreator.Mode.DISABLED)
     private constructor(
         private val aggregateBy: JsonField<MutableMap<String, AggregateBy>>,
-        private val computeAttributes: JsonField<ComputeAttributes>,
+        private val computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>,
         private val distanceMetric: JsonField<DistanceMetric>,
         private val excludeAttributes: JsonField<List<String>>,
         private val filters: JsonField<Filter>,
@@ -689,7 +689,7 @@ private constructor(
             aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of(),
             @JsonProperty("compute_attributes")
             @ExcludeMissing
-            computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of(),
+            computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> = JsonMissing.of(),
             @JsonProperty("distance_metric")
             @ExcludeMissing
             distanceMetric: JsonField<DistanceMetric> = JsonMissing.of(),
@@ -736,7 +736,7 @@ private constructor(
          * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if
          *   the server responded with an unexpected value).
          */
-        fun computeAttributes(): Optional<ComputeAttributes> =
+        fun computeAttributes(): Optional<MutableMap<String, ComputeAttributes>> =
             computeAttributes.getOptional("compute_attributes")
 
         /**
@@ -842,7 +842,8 @@ private constructor(
          */
         @JsonProperty("compute_attributes")
         @ExcludeMissing
-        fun _computeAttributes(): JsonField<ComputeAttributes> = computeAttributes
+        fun _computeAttributes(): JsonField<MutableMap<String, ComputeAttributes>> =
+            computeAttributes
 
         /**
          * Returns the raw JSON value of [distanceMetric].
@@ -917,7 +918,8 @@ private constructor(
         class Builder internal constructor() {
 
             private var aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of()
-            private var computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of()
+            private var computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> =
+                JsonMissing.of()
             private var distanceMetric: JsonField<DistanceMetric> = JsonMissing.of()
             private var excludeAttributes: JsonField<MutableList<String>>? = null
             private var filters: JsonField<Filter> = JsonMissing.of()
@@ -964,19 +966,19 @@ private constructor(
              * Computes additional values on documents returned by a query. Each key is the name of
              * the computed attribute; each value is an expression describing how to compute it.
              */
-            fun computeAttributes(computeAttributes: ComputeAttributes) =
+            fun computeAttributes(computeAttributes: MutableMap<String, ComputeAttributes>) =
                 computeAttributes(JsonField.of(computeAttributes))
 
             /**
              * Sets [Builder.computeAttributes] to an arbitrary JSON value.
              *
              * You should usually call [Builder.computeAttributes] with a well-typed
-             * [ComputeAttributes] value instead. This method is primarily for setting the field to
-             * an undocumented or not yet supported value.
+             * `MutableMap<String, ComputeAttributes>` value instead. This method is primarily for
+             * setting the field to an undocumented or not yet supported value.
              */
-            fun computeAttributes(computeAttributes: JsonField<ComputeAttributes>) = apply {
-                this.computeAttributes = computeAttributes
-            }
+            fun computeAttributes(
+                computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>
+            ) = apply { this.computeAttributes = computeAttributes }
 
             /** A function used to calculate vector similarity. */
             fun distanceMetric(distanceMetric: DistanceMetric) =
@@ -1192,9 +1194,8 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
-            computeAttributes().ifPresent { it.validate() }
+            computeAttributes()
             distanceMetric().ifPresent { it.validate() }
             excludeAttributes()
             groupBy()
@@ -1221,13 +1222,13 @@ private constructor(
         @JvmSynthetic
         internal fun validity(): Int =
             (if (aggregateBy.asKnown().isPresent()) 1 else 0) +
+                (if (computeAttributes.asKnown().isPresent()) 1 else 0) +
                 (distanceMetric.asKnown().getOrNull()?.validity() ?: 0) +
                 (excludeAttributes.asKnown().getOrNull()?.size ?: 0) +
                 (groupBy.asKnown().getOrNull()?.size ?: 0) +
                 (includeAttributes.asKnown().getOrNull()?.validity() ?: 0) +
                 (limit.asKnown().getOrNull()?.validity() ?: 0) +
                 (if (topK.asKnown().isPresent) 1 else 0)
-
 
         override fun equals(other: Any?): Boolean {
             if (this === other) {
@@ -1268,127 +1269,6 @@ private constructor(
 
         override fun toString() =
             "Query{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, additionalProperties=$additionalProperties}"
-        /**
-         * Computes additional values on documents returned by a query. Each key is the name of the
-         * computed attribute; each value is an expression describing how to compute it.
-         */
-        class ComputeAttributes
-        @JsonCreator
-        private constructor(
-            @com.fasterxml.jackson.annotation.JsonValue
-            private val additionalProperties: Map<String, JsonValue>
-        ) {
-
-            @JsonAnyGetter
-            @ExcludeMissing
-            fun _additionalProperties(): Map<String, JsonValue> = additionalProperties
-
-            fun toBuilder() = Builder().from(this)
-
-            companion object {
-
-                /**
-                 * Returns a mutable builder for constructing an instance of [ComputeAttributes].
-                 */
-                @JvmStatic fun builder() = Builder()
-            }
-
-            /** A builder for [ComputeAttributes]. */
-            class Builder internal constructor() {
-
-                private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
-
-                @JvmSynthetic
-                internal fun from(computeAttributes: ComputeAttributes) = apply {
-                    additionalProperties = computeAttributes.additionalProperties.toMutableMap()
-                }
-
-                fun additionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
-                    this.additionalProperties.clear()
-                    putAllAdditionalProperties(additionalProperties)
-                }
-
-                fun putAdditionalProperty(key: String, value: JsonValue) = apply {
-                    additionalProperties.put(key, value)
-                }
-
-                fun putAllAdditionalProperties(additionalProperties: Map<String, JsonValue>) =
-                    apply {
-                        this.additionalProperties.putAll(additionalProperties)
-                    }
-
-                fun removeAdditionalProperty(key: String) = apply {
-                    additionalProperties.remove(key)
-                }
-
-                fun removeAllAdditionalProperties(keys: Set<String>) = apply {
-                    keys.forEach(::removeAdditionalProperty)
-                }
-
-                /**
-                 * Returns an immutable instance of [ComputeAttributes].
-                 *
-                 * Further updates to this [Builder] will not mutate the returned instance.
-                 */
-                fun build(): ComputeAttributes =
-                    ComputeAttributes(additionalProperties.toImmutable())
-            }
-
-            private var validated: Boolean = false
-
-            /**
-             * Validates that the types of all values in this object match their expected types
-             * recursively.
-             *
-             * This method is _not_ forwards compatible with new types from the API for existing
-             * fields.
-             *
-             * @throws TurbopufferInvalidDataException if any value type in this object doesn't
-             *   match its expected type.
-             */
-            fun validate(): ComputeAttributes = apply {
-                if (validated) {
-                    return@apply
-                }
-
-                validated = true
-            }
-
-            fun isValid(): Boolean =
-                try {
-                    validate()
-                    true
-                } catch (e: TurbopufferInvalidDataException) {
-                    false
-                }
-
-            /**
-             * Returns a score indicating how many valid values are contained in this object
-             * recursively.
-             *
-             * Used for best match union deserialization.
-             */
-            @JvmSynthetic
-            internal fun validity(): Int =
-                additionalProperties.count { (_, value) -> !value.isNull() && !value.isMissing() }
-
-            override fun equals(other: Any?): Boolean {
-                if (this === other) {
-                    return true
-                }
-
-                return other is ComputeAttributes &&
-                    additionalProperties == other.additionalProperties
-            }
-
-            private val hashCode: Int by lazy { Objects.hash(additionalProperties) }
-
-            override fun hashCode(): Int = hashCode
-
-            override fun toString() =
-                "ComputeAttributes{additionalProperties=$additionalProperties}"
-        }
-
     }
 
     /** The consistency level for a query. */

--- a/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceQueryParams.kt
+++ b/turbopuffer-java-core/src/main/kotlin/com/turbopuffer/models/namespaces/NamespaceQueryParams.kt
@@ -48,7 +48,8 @@ private constructor(
      * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if the
      *   server responded with an unexpected value).
      */
-    fun computeAttributes(): Optional<ComputeAttributes> = body.computeAttributes()
+    fun computeAttributes(): Optional<MutableMap<String, ComputeAttributes>> =
+        body.computeAttributes()
 
     /**
      * The consistency level for a query.
@@ -159,7 +160,8 @@ private constructor(
      * Unlike [computeAttributes], this method doesn't throw if the JSON field has an unexpected
      * type.
      */
-    fun _computeAttributes(): JsonField<ComputeAttributes> = body._computeAttributes()
+    fun _computeAttributes(): JsonField<MutableMap<String, ComputeAttributes>> =
+        body._computeAttributes()
 
     /**
      * Returns the raw JSON value of [consistency].
@@ -292,7 +294,7 @@ private constructor(
          * Computes additional values on documents returned by a query. Each key is the name of the
          * computed attribute; each value is an expression describing how to compute it.
          */
-        fun computeAttributes(computeAttributes: ComputeAttributes) = apply {
+        fun computeAttributes(computeAttributes: MutableMap<String, ComputeAttributes>) = apply {
             body.computeAttributes(computeAttributes)
         }
 
@@ -303,9 +305,10 @@ private constructor(
          * value instead. This method is primarily for setting the field to an undocumented or not
          * yet supported value.
          */
-        fun computeAttributes(computeAttributes: JsonField<ComputeAttributes>) = apply {
-            body.computeAttributes(computeAttributes)
-        }
+        fun computeAttributes(computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>) =
+            apply {
+                body.computeAttributes(computeAttributes)
+            }
 
         /** The consistency level for a query. */
         fun consistency(consistency: Consistency) = apply { body.consistency(consistency) }
@@ -612,7 +615,7 @@ private constructor(
     @JsonCreator(mode = JsonCreator.Mode.DISABLED)
     private constructor(
         private val aggregateBy: JsonField<MutableMap<String, AggregateBy>>,
-        private val computeAttributes: JsonField<ComputeAttributes>,
+        private val computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>,
         private val consistency: JsonField<Consistency>,
         private val distanceMetric: JsonField<DistanceMetric>,
         private val excludeAttributes: JsonField<List<String>>,
@@ -633,7 +636,7 @@ private constructor(
             aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of(),
             @JsonProperty("compute_attributes")
             @ExcludeMissing
-            computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of(),
+            computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> = JsonMissing.of(),
             @JsonProperty("consistency")
             @ExcludeMissing
             consistency: JsonField<Consistency> = JsonMissing.of(),
@@ -688,7 +691,7 @@ private constructor(
          * @throws TurbopufferInvalidDataException if the JSON field has an unexpected type (e.g. if
          *   the server responded with an unexpected value).
          */
-        fun computeAttributes(): Optional<ComputeAttributes> =
+        fun computeAttributes(): Optional<MutableMap<String, ComputeAttributes>> =
             computeAttributes.getOptional("compute_attributes")
 
         /**
@@ -811,7 +814,8 @@ private constructor(
          */
         @JsonProperty("compute_attributes")
         @ExcludeMissing
-        fun _computeAttributes(): JsonField<ComputeAttributes> = computeAttributes
+        fun _computeAttributes(): JsonField<MutableMap<String, ComputeAttributes>> =
+            computeAttributes
 
         /**
          * Returns the raw JSON value of [consistency].
@@ -905,7 +909,8 @@ private constructor(
         class Builder internal constructor() {
 
             private var aggregateBy: JsonField<MutableMap<String, AggregateBy>> = JsonMissing.of()
-            private var computeAttributes: JsonField<ComputeAttributes> = JsonMissing.of()
+            private var computeAttributes: JsonField<MutableMap<String, ComputeAttributes>> =
+                JsonMissing.of()
             private var consistency: JsonField<Consistency> = JsonMissing.of()
             private var distanceMetric: JsonField<DistanceMetric> = JsonMissing.of()
             private var excludeAttributes: JsonField<MutableList<String>>? = null
@@ -956,19 +961,19 @@ private constructor(
              * Computes additional values on documents returned by a query. Each key is the name of
              * the computed attribute; each value is an expression describing how to compute it.
              */
-            fun computeAttributes(computeAttributes: ComputeAttributes) =
+            fun computeAttributes(computeAttributes: MutableMap<String, ComputeAttributes>) =
                 computeAttributes(JsonField.of(computeAttributes))
 
             /**
              * Sets [Builder.computeAttributes] to an arbitrary JSON value.
              *
              * You should usually call [Builder.computeAttributes] with a well-typed
-             * [ComputeAttributes] value instead. This method is primarily for setting the field to
-             * an undocumented or not yet supported value.
+             * `MutableMap<String, ComputeAttributes>` value instead. This method is primarily for
+             * setting the field to an undocumented or not yet supported value.
              */
-            fun computeAttributes(computeAttributes: JsonField<ComputeAttributes>) = apply {
-                this.computeAttributes = computeAttributes
-            }
+            fun computeAttributes(
+                computeAttributes: JsonField<MutableMap<String, ComputeAttributes>>
+            ) = apply { this.computeAttributes = computeAttributes }
 
             /** The consistency level for a query. */
             fun consistency(consistency: Consistency) = consistency(JsonField.of(consistency))
@@ -1209,9 +1214,8 @@ private constructor(
                 return@apply
             }
 
-
             aggregateBy()
-            computeAttributes().ifPresent { it.validate() }
+            computeAttributes()
             consistency().ifPresent { it.validate() }
             distanceMetric().ifPresent { it.validate() }
             excludeAttributes()
@@ -1240,6 +1244,7 @@ private constructor(
         @JvmSynthetic
         internal fun validity(): Int =
             (if (aggregateBy.asKnown().isPresent()) 1 else 0) +
+                (if (computeAttributes.asKnown().isPresent()) 1 else 0) +
                 (consistency.asKnown().getOrNull()?.validity() ?: 0) +
                 (distanceMetric.asKnown().getOrNull()?.validity() ?: 0) +
                 (excludeAttributes.asKnown().getOrNull()?.size ?: 0) +
@@ -1291,119 +1296,6 @@ private constructor(
 
         override fun toString() =
             "Body{aggregateBy=$aggregateBy, computeAttributes=$computeAttributes, consistency=$consistency, distanceMetric=$distanceMetric, excludeAttributes=$excludeAttributes, filters=$filters, groupBy=$groupBy, includeAttributes=$includeAttributes, limit=$limit, rankBy=$rankBy, topK=$topK, vectorEncoding=$vectorEncoding, additionalProperties=$additionalProperties}"
-    }
-
-
-    /**
-     * Computes additional values on documents returned by a query. Each key is the name of the
-     * computed attribute; each value is an expression describing how to compute it.
-     */
-    class ComputeAttributes
-    @JsonCreator
-    private constructor(
-        @com.fasterxml.jackson.annotation.JsonValue
-        private val additionalProperties: Map<String, JsonValue>
-    ) {
-
-        @JsonAnyGetter
-        @ExcludeMissing
-        fun _additionalProperties(): Map<String, JsonValue> = additionalProperties
-
-        fun toBuilder() = Builder().from(this)
-
-        companion object {
-
-            /** Returns a mutable builder for constructing an instance of [ComputeAttributes]. */
-            @JvmStatic fun builder() = Builder()
-        }
-
-        /** A builder for [ComputeAttributes]. */
-        class Builder internal constructor() {
-
-            private var additionalProperties: MutableMap<String, JsonValue> = mutableMapOf()
-
-            @JvmSynthetic
-            internal fun from(computeAttributes: ComputeAttributes) = apply {
-                additionalProperties = computeAttributes.additionalProperties.toMutableMap()
-            }
-
-            fun additionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
-                this.additionalProperties.clear()
-                putAllAdditionalProperties(additionalProperties)
-            }
-
-            fun putAdditionalProperty(key: String, value: JsonValue) = apply {
-                additionalProperties.put(key, value)
-            }
-
-            fun putAllAdditionalProperties(additionalProperties: Map<String, JsonValue>) = apply {
-                this.additionalProperties.putAll(additionalProperties)
-            }
-
-            fun removeAdditionalProperty(key: String) = apply { additionalProperties.remove(key) }
-
-            fun removeAllAdditionalProperties(keys: Set<String>) = apply {
-                keys.forEach(::removeAdditionalProperty)
-            }
-
-            /**
-             * Returns an immutable instance of [ComputeAttributes].
-             *
-             * Further updates to this [Builder] will not mutate the returned instance.
-             */
-            fun build(): ComputeAttributes = ComputeAttributes(additionalProperties.toImmutable())
-        }
-
-        private var validated: Boolean = false
-
-        /**
-         * Validates that the types of all values in this object match their expected types
-         * recursively.
-         *
-         * This method is _not_ forwards compatible with new types from the API for existing fields.
-         *
-         * @throws TurbopufferInvalidDataException if any value type in this object doesn't match
-         *   its expected type.
-         */
-        fun validate(): ComputeAttributes = apply {
-            if (validated) {
-                return@apply
-            }
-
-            validated = true
-        }
-
-        fun isValid(): Boolean =
-            try {
-                validate()
-                true
-            } catch (e: TurbopufferInvalidDataException) {
-                false
-            }
-
-        /**
-         * Returns a score indicating how many valid values are contained in this object
-         * recursively.
-         *
-         * Used for best match union deserialization.
-         */
-        @JvmSynthetic
-        internal fun validity(): Int =
-            additionalProperties.count { (_, value) -> !value.isNull() && !value.isMissing() }
-
-        override fun equals(other: Any?): Boolean {
-            if (this === other) {
-                return true
-            }
-
-            return other is ComputeAttributes && additionalProperties == other.additionalProperties
-        }
-
-        private val hashCode: Int by lazy { Objects.hash(additionalProperties) }
-
-        override fun hashCode(): Int = hashCode
-
-        override fun toString() = "ComputeAttributes{additionalProperties=$additionalProperties}"
     }
 
     /** The consistency level for a query. */

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/models/namespaces/ComputeAttributesTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/models/namespaces/ComputeAttributesTest.kt
@@ -1,0 +1,32 @@
+package com.turbopuffer.models.namespaces
+
+import com.turbopuffer.core.jsonMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class ComputeAttributesTest {
+
+    @Test
+    fun serializesEveryVariant() {
+        val jsonMapper = jsonMapper()
+
+        // VectorDist: attr="vec", "VectorDist", vector=[0.5]
+        val vectorDist: ComputeAttributes = ComputeAttributes.vectorDist("vec", listOf(0.5f))
+        assertThat(jsonMapper.writeValueAsString(vectorDist))
+            .isEqualTo("""["vec","VectorDist",[0.5]]""")
+
+        // Highlight: "Highlight", attr="body"
+        val highlight: ComputeAttributes = ComputeAttributes.highlight("body")
+        assertThat(jsonMapper.writeValueAsString(highlight)).isEqualTo("""["Highlight","body"]""")
+
+        // HighlightWithConfig: "Highlight", "body", config (empty)
+        val highlightWithConfig: ComputeAttributes =
+            ComputeAttributes.highlight("body", HighlightConfigParams.builder().build())
+        assertThat(jsonMapper.writeValueAsString(highlightWithConfig))
+            .isEqualTo("""["Highlight","body",{}]""")
+
+        // Score / RankBy: ANN attr="vec", vector=[0.5]
+        val rankBy: ComputeAttributes = RankBy.ann("vec", listOf(0.5f))
+        assertThat(jsonMapper.writeValueAsString(rankBy)).isEqualTo("""["vec","ANN",[0.5]]""")
+    }
+}

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/async/NamespaceServiceAsyncTest.kt
@@ -98,7 +98,6 @@ internal class NamespaceServiceAsyncTest {
             namespaceServiceAsync.explainQuery(
                 NamespaceExplainQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)
@@ -152,7 +151,6 @@ internal class NamespaceServiceAsyncTest {
                     .namespace("namespace")
                     .addQuery(
                         NamespaceMultiQueryParams.Query.builder()
-
                             .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                             .addExcludeAttribute("string")
                             .includeAttributes(true)
@@ -184,7 +182,6 @@ internal class NamespaceServiceAsyncTest {
             namespaceServiceAsync.query(
                 NamespaceQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)

--- a/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
+++ b/turbopuffer-java-core/src/test/kotlin/com/turbopuffer/services/blocking/NamespaceServiceTest.kt
@@ -95,7 +95,6 @@ internal class NamespaceServiceTest {
             namespaceService.explainQuery(
                 NamespaceExplainQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)
@@ -145,7 +144,6 @@ internal class NamespaceServiceTest {
                     .namespace("namespace")
                     .addQuery(
                         NamespaceMultiQueryParams.Query.builder()
-
                             .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                             .addExcludeAttribute("string")
                             .includeAttributes(true)
@@ -176,7 +174,6 @@ internal class NamespaceServiceTest {
             namespaceService.query(
                 NamespaceQueryParams.builder()
                     .namespace("namespace")
-
                     .distanceMetric(DistanceMetric.COSINE_DISTANCE)
                     .addExcludeAttribute("string")
                     .includeAttributes(true)


### PR DESCRIPTION
Types the `compute_attributes` query param as `Map<String, ComputeAttributes>` (the rich union), mirroring the existing custom override for `aggregate_by` → `Map<String, AggregateBy>`. Applied to all three params files: `NamespaceQueryParams`, `NamespaceExplainQueryParams`, and `NamespaceMultiQueryParams` (the latter via the build-time `extractQueryClass` extraction from the `Query` block).

The opaque nested `ComputeAttributes` class is removed in favor of the `ComputeAttributes` union in `CustomTypes.kt`. `JsonField<…>` wiring, builder setters, getters, `validate()`, and `validity()` are all updated consistently to match the `aggregateBy` pattern.

## Notes on generated code

`CustomTypes.kt` was regenerated via `scripts/gen` (apigen) to pull in the `ComputeAttributes` union body, which was **not yet present on `next`** (PR #249 landed the opaque param typing but its union-body addition to `CustomTypes.kt` had not merged into `next`). apigen already emits the union (`ComputeAttributesVectorDist`, `ComputeAttributesHighlight`, `ComputeAttributesHighlightWithConfig`), so `scripts/gen` regenerates it cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)